### PR TITLE
chore: Update maximum compatible version of package_info_plus

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   implicitly_animated_list: ^2.1.1
   json_view: ^0.4.2
   meta: ^1.3.0
-  package_info_plus: '>=3.0.0 <6.0.0'
+  package_info_plus: '>=3.0.0 <9.0.0'
   shake: ^2.0.0
 
 dev_dependencies:


### PR DESCRIPTION
Hey @JonasWanke ,


since the package is using a very old version of package_info_plus, it is not possible to run it in the same repo with newer packages that rely on newer versions of `package_info_plus`.


I have tested with this version. No don't use the dependency in any way that is breaking with the new vbersion ( only `PackageInfo.fromPlatform()` is used which hasn't changed in the latest version `8.0.0`).


It would be great if this can get merged soon, to unblock us and that we can keep using the debug overlay as it is really useful.

Thank you.
